### PR TITLE
Reduce limiter to 100 

### DIFF
--- a/lambda/service_monitor.py
+++ b/lambda/service_monitor.py
@@ -53,7 +53,7 @@ def list_discovered_resources(config_client, resource_type):
     paginator = config_client.get_paginator('list_discovered_resources')
     response_iterator = paginator.paginate(
         resourceType=resource_type,
-        limit=1000
+        limit=100
     )
     
     resources = []


### PR DESCRIPTION
Error:
Error discovering resources for AWS::Route53Resolver::FirewallRuleGroup: An error occurred (ValidationException) when calling the ListDiscoveredResources operation: 1 validation error detected: Value '900' at 'limit' failed to satisfy constraint: Member must have value less than or equal to 100